### PR TITLE
docs: refactor charm test how-tos

### DIFF
--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -21,7 +21,7 @@ Every unit test involves a mocked event context, as charms only execute in respo
 
 Charm unit testing uses [`ops.testing`](ops_testing) framework for state-transition testing. `State` mocks inputs and outputs, while `Context` and `Container` offer a mock filesystem. Tests involve setup (charm, metadata, context, output mocks, Juju state), event simulation via `Context.run`, output retrieval, and assertions. `Context` and `State` are instantiated before the charm, allowing pre-event state setup (storage, relations, config). `Context` provides methods for simulating various Juju events like `config_changed`, `relation_created`, `relation_joined`, `relation_changed`, `relation_departed`, `storage_attached`, `storage_detached`, `pebble_ready`, and so on.
 
-> See also: {ref}`write-legacy-unit-tests-for-a-charm`, {ref}`write-scenario-tests-for-a-charm`.
+> See also: {ref}`write-legacy-unit-tests-for-a-charm`, {ref}`write-unit-tests-for-a-charm`.
 
 ### Coverage
 

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -145,12 +145,6 @@ def _on_snapshot(self, event: ops.ActionEvent):
 ```
 > See more: [](ops.ActionEvent.id)
 
-## Test the feature
-
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-What you need to do depends on what kind of tests you want to write.
-
 ### Write unit tests
 
 > See first: {ref}`write-unit-tests-for-a-charm`

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -147,13 +147,13 @@ def _on_snapshot(self, event: ops.ActionEvent):
 
 ## Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 What you need to do depends on what kind of tests you want to write.
 
 ### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 To verify that the charm state is as expected after executing an action, use the `run` method of the `Context` object, with `ctx.on.action`. The context contains any logs and results that the charm set.
 

--- a/docs/howto/manage-configurations.md
+++ b/docs/howto/manage-configurations.md
@@ -61,10 +61,6 @@ def _on_config_changed(self, event):
 https://github.com/canonical/juju-sdk-tutorial-k8s/compare/01_create_minimal_charm...02_make_your_charm_configurable
 -->
 
-## Test the feature
-
-> See first: {ref}`write-unit-tests-for-a-charm`
-
 ### Write unit tests
 
 > See first: {ref}`write-unit-tests-for-a-charm`

--- a/docs/howto/manage-configurations.md
+++ b/docs/howto/manage-configurations.md
@@ -63,11 +63,11 @@ https://github.com/canonical/juju-sdk-tutorial-k8s/compare/01_create_minimal_cha
 
 ## Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 ### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 To verify that the `config-changed` event validates the port, pass the new config to the `State`, and, after running the event, check the unit status. For example, in your `tests/unit/test_charm.py` file, add the following test function:
 

--- a/docs/howto/manage-leadership-changes.md
+++ b/docs/howto/manage-leadership-changes.md
@@ -45,10 +45,6 @@ Note that Juju guarantees leadership for only 30 seconds after a `leader-elected
 event or an `is-leader` check. If the charm code may run longer, then extra
 `is_leader()` calls should be made to ensure that the unit is still the leader.
 
-## Test response to leadership changes
-
-> See first: {ref}`write-unit-tests-for-a-charm`
-
 ### Write unit tests
 
 > See first: {ref}`write-unit-tests-for-a-charm`

--- a/docs/howto/manage-leadership-changes.md
+++ b/docs/howto/manage-leadership-changes.md
@@ -47,11 +47,11 @@ event or an `is-leader` check. If the charm code may run longer, then extra
 
 ## Test response to leadership changes
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 ### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 To verify behaviour when leadership has changed, pass the leadership status to the `State`. For example:
 

--- a/docs/howto/manage-opened-ports.md
+++ b/docs/howto/manage-opened-ports.md
@@ -32,7 +32,7 @@ You'll want to add unit and integration tests.
 
 ### Write unit tests
 
-> See first: {ref}`write-unit-tests-for-a-charm`, {ref}`write-unit-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 In your unit tests, use the [](ops.testing.State.opened_ports) component of the
 input `State` to specify which ports are already open when the event is

--- a/docs/howto/manage-opened-ports.md
+++ b/docs/howto/manage-opened-ports.md
@@ -32,7 +32,7 @@ You'll want to add unit and integration tests.
 
 ### Write unit tests
 
-> See first: {ref}`get-started-with-charm-testing`, {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`, {ref}`write-unit-tests-for-a-charm`
 
 In your unit tests, use the [](ops.testing.State.opened_ports) component of the
 input `State` to specify which ports are already open when the event is
@@ -52,7 +52,7 @@ def test_open_port():
 
 ### Write integration tests
 
-> See first: {ref}`get-started-with-charm-testing`, {ref}`write-integration-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`, {ref}`write-integration-tests-for-a-charm`
 
 To verify that the correct ports are open in an integration test, deploy your
 charm as usual, and then try to connect to the appropriate ports.

--- a/docs/howto/manage-storage.md
+++ b/docs/howto/manage-storage.md
@@ -123,13 +123,13 @@ has attached the new storage.
 
 ## Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 You'll want to add unit and integration tests:
 
 ### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 To verify that the charm state is as expected after storage changes, use the `run` method of the `Context` object. For example, to provide the charm with mock storage:
 

--- a/docs/howto/manage-storage.md
+++ b/docs/howto/manage-storage.md
@@ -121,12 +121,6 @@ The storage will not be available immediately after that call - the charm should
 observe the `storage-attached` event and handle any remaining setup once Juju
 has attached the new storage.
 
-## Test the feature
-
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-You'll want to add unit and integration tests:
-
 ### Write unit tests
 
 > See first: {ref}`write-unit-tests-for-a-charm`

--- a/docs/howto/manage-stored-state.md
+++ b/docs/howto/manage-stored-state.md
@@ -71,7 +71,7 @@ def _on_install(self, event: ops.InstallEvent):
 
 ### Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 You'll want to add unit tests.
 
@@ -82,7 +82,7 @@ an integration test: just trigger multiple Juju events.
 
 #### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 Add `StoredState` objects to the `State` with any content that you want to mock
 having persisted from a previous event. For example, in your
@@ -151,7 +151,7 @@ to wait until later events, like `start`, to store and retrieve data.
 
 ### Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 You'll want to add unit tests.
 
@@ -162,7 +162,7 @@ an integration test: just trigger multiple Juju events.
 
 #### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 In your `tests/unit/test_charm.py` file, add tests that have an initial state
 that includes a [](ops.testing.PeerRelation) object.

--- a/docs/howto/manage-stored-state.md
+++ b/docs/howto/manage-stored-state.md
@@ -71,8 +71,6 @@ def _on_install(self, event: ops.InstallEvent):
 
 ### Test the feature
 
-> See first: {ref}`write-unit-tests-for-a-charm`
-
 You'll want to add unit tests.
 
 For integration tests: stored state isn't a feature, it's functionality that

--- a/docs/howto/manage-the-charm-version.md
+++ b/docs/howto/manage-the-charm-version.md
@@ -43,8 +43,6 @@ uploading a charm to CharmHub (or when deploying/refreshing for local charms).
 
 ## Test the feature
 
-> See first: {ref}`write-unit-tests-for-a-charm`
-
 Since the version isn't set by the charm code itself, you'll want to test that
 the version is correctly set with an integration test, and don't need to write
 a unit test.

--- a/docs/howto/manage-the-charm-version.md
+++ b/docs/howto/manage-the-charm-version.md
@@ -43,7 +43,7 @@ uploading a charm to CharmHub (or when deploying/refreshing for local charms).
 
 ## Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 Since the version isn't set by the charm code itself, you'll want to test that
 the version is correctly set with an integration test, and don't need to write

--- a/docs/howto/manage-the-workload-version.md
+++ b/docs/howto/manage-the-workload-version.md
@@ -53,13 +53,13 @@ def _on_start(self, event: ops.StartEvent):
 
 ## Test the feature
 
-> See first: {ref}`get-started-with-charm-testing`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 You'll want to add unit and integration tests.
 
 ### Write unit tests
 
-> See first: {ref}`write-scenario-tests-for-a-charm`
+> See first: {ref}`write-unit-tests-for-a-charm`
 
 To verify the workload version is set in a unit test, retrieve the workload
 version from the `State`. In your `tests/unit/test_charm.py` file, add a

--- a/docs/howto/manage-the-workload-version.md
+++ b/docs/howto/manage-the-workload-version.md
@@ -51,12 +51,6 @@ def _on_start(self, event: ops.StartEvent):
 
 > Examples: [`jenkins-k8s` sets the workload version after getting it from the Jenkins package](https://github.com/canonical/jenkins-k8s-operator/blob/29e9b652714bd8314198965c41a60f5755dd381c/src/charm.py#L115), [`discourse-k8s` sets the workload version after getting it via an exec call](https://github.com/canonical/discourse-k8s-operator/blob/f523b29f909c69da7b9510b581dfcc2309698222/src/charm.py#L581), [`synapse` sets the workload version after getting it via an API call](https://github.com/canonical/synapse-operator/blob/778bcd414644c922373d542a304be14866835516/src/charm.py#L265)
 
-## Test the feature
-
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-You'll want to add unit and integration tests.
-
 ### Write unit tests
 
 > See first: {ref}`write-unit-tests-for-a-charm`

--- a/docs/howto/turn-a-hooks-based-charm-into-an-ops-charm.md
+++ b/docs/howto/turn-a-hooks-based-charm-into-an-ops-charm.md
@@ -286,7 +286,7 @@ The final result can be inspected at [this branch](https://github.com/PietroPaso
 
 ### Testing
 
-After you've prepared the event handlers, you should write tests for the charm. See {ref}`write-unit-tests-for-a-charm`.
+After you've prepared the event handlers, you should write tests for the charm. See {ref}`write-unit-tests-for-a-charm` and {ref}`write-integration-tests-for-a-charm`.
 
 ## Closing notes
 

--- a/docs/howto/turn-a-hooks-based-charm-into-an-ops-charm.md
+++ b/docs/howto/turn-a-hooks-based-charm-into-an-ops-charm.md
@@ -286,7 +286,7 @@ The final result can be inspected at [this branch](https://github.com/PietroPaso
 
 ### Testing
 
-After you've prepared the event handlers, you should write tests for the charm. See {ref}`get-started-with-charm-testing`.
+After you've prepared the event handlers, you should write tests for the charm. See {ref}`write-unit-tests-for-a-charm`.
 
 ## Closing notes
 

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -7,7 +7,7 @@ This document shows how to write integration tests for a charm.
 
 ```{important}
 
-Integration testing is only one part of a comprehensive testing strategy. Also see {ref}`write-scenario-tests-for-a-charm`.
+Integration testing is only one part of a comprehensive testing strategy. Also see {ref}`write-unit-tests-for-a-charm`.
 
 ```
 
@@ -53,7 +53,44 @@ import pytest
 from pytest_operator.plugin import OpsTest
 ```
 
-The `ops_test` fixture is your entry point to the `pytest-operator` library, and the preferred way of interacting with Juju in integration tests. This fixture will create a model for each test file -- if you write two tests that should not share a model, make sure to place them in different files.
+The `ops_test` fixture is your entry point to the `pytest-operator` library, and the preferred way of interacting with Juju in integration tests. The fixture will create a model for each test file -- if you write two tests that should not share a model, make sure to place them in different files. The fixture is a module-scoped context which, on entry, adds to Juju a randomly-named new model and destroys it on exit. All tests in that module, and all interactions with the `ops_test` object, will take place against that model. Once you have used `ops_test` to get a model in which to run your integration tests, most of the remaining integration test code will interact with Juju via the `python-libjuju` package.  
+
+```{note}
+
+*Pro tip*: you can prevent `ops_test` from tearing down the model on exit by passing the `--keep-models` argument. This is useful when the tests fail and the logs don't provide a sufficient post-mortem and a real live autopsy is required.
+
+```
+
+Below is an example of a typical integration test:
+
+```python
+async def test_operation(ops_test: OpsTest):
+    # Tweak the config:
+    app: Application = ops_test.model.applications.get("tester")
+    await app.set_config({"my-key": "my-value"})
+    
+    # Add another charm and integrate them:
+    await ops_test.model.deploy('other-app')
+    await ops_test.model.relate('tester:endpoint1', 'other-charm:endpoint2')
+    
+    # Scale it up:
+    await app.add_unit(2)
+    
+    # Remove another app:
+    await ops_test.model.remove_application('yet-another-app')
+    
+    # Run an action on a unit:
+    unit: Unit = app.units[1]
+    action = await unit.run('my-action')
+    assert action.results == <foo>
+    
+    # What this means depends on the workload:
+    assert charm_operates_correctly()  
+```
+
+`python-libjuju` has, of course, an API for all inverse operations: remove an app, scale it down, remove a relation...
+
+A good integration testing suite will check that the charm continues to operate as expected whenever possible, by combining these simple elements.
 
 ## Build your tests
 
@@ -129,7 +166,6 @@ For `oci-images` you can reference an image registry.
 > - [`pytest-operator` |  `download_resources`](https://github.com/charmed-kubernetes/pytest-operator/blob/ab50fc20320d3ea3d8a37495f92a004531a4023f/pytest_operator/plugin.py#L1101)
 > - [`python-libjuju` | `model.deploy`](https://github.com/juju/python-libjuju/blob/2581b0ced1df6201c6b7fd8cc0b20dcfa9d97c51/juju/model.py#L1658)
 
-
 ### Test a relation
 
 To test a relation between two applications, integrate them through
@@ -168,8 +204,6 @@ async def test_config_changed(ops_test: OpsTest):
 > See also: https://discourse.charmhub.io/t/how-to-add-a-configuration-option-to-a-charm/4458
 >
 > See also: [python-libjuju | application.set_config](https://github.com/juju/python-libjuju/blob/2581b0ced1df6201c6b7fd8cc0b20dcfa9d97c51/juju/application.py#L591)
-
-
 
 ### Test an action
 
@@ -289,7 +323,6 @@ It is not recommended to use `ops_test.build_bundle` and `ops_test.deploy_bundle
 
 ```
 
-
 ### Render bundles and charms
 
 `pytest-operator` has utilities to template your charms and bundles using Jinja2.
@@ -319,8 +352,6 @@ async def test_build_and_deploy_bundle(ops_test: OpsTest):
 
 
 > Example implementations: [`hardware-observer-operator`](https://github.com/canonical/hardware-observer-operator/blob/47a79eb2872f6222099e7f48b8daafe8d20aa946/tests/functional/test_charm.py#L57)
-
-
 
 ### Speed up `update_status`  with `fast_forward`
 

--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -1,25 +1,18 @@
-(write-scenario-tests-for-a-charm)=
+(write-unit-tests-for-a-charm)=
 # How to write unit tests for a charm
 
-```{note}
+## Setting up
 
-This page is currently being refactored.
-
-```
-
-First of all, install the Ops testing framework. To do this in a virtual environment
-while you are developing, use `pip` or another package
-manager. For example:
+First of all, install the Ops testing framework. To do this in a virtual environment while we are developing, use `pip` or other package managers. For example:
 
 ```
 pip install ops[testing]
 ```
 
-Normally, you'll include this in the dependency group for your unit tests, for
-example in a test-requirements.txt file:
+Normally, we'll include this and pin-point it to the latest minor version in the dependency group for our unit tests, for example in a `test-requirements.txt` file:
 
 ```text
-ops[testing] ~= 2.17
+ops[testing] ~= 2.19
 ```
 
 Or in `pyproject.toml`:
@@ -27,57 +20,88 @@ Or in `pyproject.toml`:
 ```toml
 [dependency-groups]
 test = [
-  "ops[testing] ~= 2.17",
+  "ops[testing] ~= 2.19",
 ]
 ```
 
-Then, open a new `test_foo.py` file where you will put the test code.
+## Creating the charm and test files
+
+Declare our new charm type in `charm.py`:
+
+```python
+class MyCharm(ops.CharmBase):
+    pass        
+```
+
+Open a new `test_foo.py` file where we will put the test code and import the [`ops.testing`](ops_testing) framework:
 
 ```python
 import ops
 from ops import testing
 ```
 
-Then declare a new charm type:
+## Writing a test
+
+To write a test function, use a `Context` object to encapsulate the charm type (`MyCharm`) and any necessary metadata. The test should then define the initial `State` and call `Context.run` with an `event` and initial `State`.
+
+This follows the typical test structure:
+
+- Arrange: arrange inputs, mock necessary functions/system calls, initialize the charm
+- Act: act by calling `Context.run`
+- Assert: assert expected outputs or function calls.
+
+For example, if `MyCharm` writes a YAML config file via `Container.Push` on the pebble-ready event:
+
 ```python
-class MyCharm(ops.CharmBase):
-    pass        
+def _on_pebble_ready(self, event: ops.PebbleReadyEvent):        
+    container = event.workload
+    container.push('/etc/config.yaml', 'message: Hello, world!', make_dirs=True)
+    # ...
 ```
 
-And finally we can write a test function. The test code should use a `Context` object to encapsulate the charm type being tested (`MyCharm`) and any necessary metadata, then declare the initial `State` the charm will be presented when run, and `run` the context with an `event` and that initial state as parameters. 
-
-In code:
+And we want to test this behaviour, the test might look like this:
 
 ```python
-def test_charm_runs():
-    # Arrange: 
-    #  Create a Context to specify what code we will be running,
+import yaml
+from ops import testing
+
+from charm import MyCharm
+
+
+def test_pebble_ready_writes_config_file():
+    """Test that on pebble-ready, a config file is written."""
+    # Arrange: setting up the inputs
     ctx = testing.Context(MyCharm)
-    #  and create a State to specify what simulated data the charm being run will access.
-    state_in = testing.State(leader=True)
+    container = testing.Container(name="some-container", can_connect=True)
+    state_in = testing.State(
+        containers=[container],
+        leader=True,
+    )
 
     # Act:
-    #  Ask the context to run an event, e.g. 'start', with the state we have previously created.
-    state_out = ctx.run(ctx.on.start(), state_in)
+    ctx.run(ctx.on.pebble_ready(container=container), state_in)
 
     # Assert:
-    #  Verify that the output state looks like you expect it to.
-    assert state_out.unit_status == testing.UnknownStatus()
+    container_root_fs = container.get_filesystem(ctx)
+    cfg_file = container_root_fs / "etc" / "config.yaml"
+    config = yaml.safe_load(cfg_file.read_text())
+    assert config["message"] == "Hello, world!"
+
+```
+
+```{note}
+
+If you like using unittest, you should rewrite this as a method of some TestCase subclass.
+
 ```
 
 > See more: 
 >  - [`State`](ops.testing.State)
 >  - [`Context`](ops.testing.Context)
 
-```{note}
-
-If you like using unittest, you should rewrite this as a method of some TestCase subclass.
-```
-
 ## Mocking beyond the State
 
-If you wish to use the framework to test an existing charm type, you will probably need to mock out certain calls that are not covered by the `State` data structure.
-In that case, you will have to manually mock, patch or otherwise simulate those calls on top of what the framework does for you.
+If you wish to use the framework to test an existing charm type, you will probably need to mock out certain calls that are not covered by the `State` data structure. In that case, you will have to manually mock, patch or otherwise simulate those calls on top of what the framework does for you.
 
 For example, suppose that the charm we're testing uses the `KubernetesServicePatch`. To update the test above to mock that object, modify the test file to contain:
 
@@ -104,101 +128,5 @@ def test_charm_runs(my_charm):
 ```{note}
 
 If you use pytest, you should put the `my_charm` fixture in a top level `conftest.py`, as it will likely be shared between all your unit tests.
+
 ```
-
----
-
-(get-started-with-charm-testing)=
-## Get started with charm testing
-
-## Unit testing
-
-### Writing a test
-
-The typical way in which we want to structure a test is:
- - arrange the required inputs
- - mock any function or system call you need to
- - initialise the charm
- - act, by calling `ctx.run`
- - assert some output matches what is expected, or some function is called with the expected parameters, etc...
-
-A simple test might look like this:
-
-```python
-from charm import MyCharm
-from ops import testing
-
-def test_pebble_ready_writes_config_file():
-    """Test that on pebble-ready, a config file is written"""
-    ctx = testing.Context(MyCharm)
-
-    relation = testing.Relation(
-        'relation-name',
-        remote_app_name='remote-app-name',
-        remote_units_data={1: {'baz': 'qux'}},
-    )
-    
-    # We are done setting up the inputs:
-    state_in = testing.State(
-      config={'foo': 'bar'},  # Mock the current charm config.
-      leader=True,  # Mock the charm leadership.
-      relations={relation},  # Mock relation data.
-    )
-
-    # This will fire a `<container-name>-pebble-ready` event.
-    state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-
-    # Suppose that MyCharm has written a YAML config file via Pebble.push():
-    container = state_out.get_container(container.name)
-    file = "path_to_config_file.yaml"
-    config = yaml.safe_load((container.get_filesystem() / file).read())
-    assert config[0]['foo']['bar'] == 'baz'  # or whatever
-``` 
-
-## Integration testing
-
-### Testing with `pytest-operator`
-
-The integration test template that `charmcraft init` provides includes the starting point for writing integration tests with `pytest-operator` and `python-libjuju`. The `tox.ini` is also configured so that you can run `tox -e integration` to run the tests, provided that you have a cloud (such as LXD or microk8s) and local Juju client.
-
-The entry point for all `pytest-operator` tests is the `ops_test` fixture. The fixture is a module-scoped context which, on entry, adds to Juju a randomly-named new model and destroys it on exit. All tests in that module, and all interactions with the `ops_test` object, will take place against that model.
-
-Once you have used `ops_test` to get a model in which to run your integration tests, most of the remaining integration test code will interact with Juju via the `python-libjuju` package.
-
-> See more: [`python-libjuju`](https://pythonlibjuju.readthedocs.io/en/latest/)
-
-```{note}
-
-*Pro tip*: you can prevent `ops_test` from tearing down the model on exit by passing the `--keep-models` argument. This is useful when the tests fail and the logs don't provide a sufficient post-mortem and a real live autopsy is required.
-```
-
-Detailed documentation of how to use `ops_test` and `pytest-operator` is out of scope for this document. However, this is an example of a typical integration test:
-
-```python
-async def test_operation(ops_test: OpsTest):
-    # Tweak the config:
-    app: Application = ops_test.model.applications.get("tester")
-    await app.set_config({"my-key": "my-value"})
-    
-    # Add another charm and integrate them:
-    await ops_test.model.deploy('other-app')
-    await ops_test.model.relate('tester:endpoint1', 'other-charm:endpoint2')
-    
-    # Scale it up:
-    await app.add_unit(2)
-    
-    # Remove another app:
-    await ops_test.model.remove_application('yet-another-app')
-    
-    # Run an action on a unit:
-    unit: Unit = app.units[1]
-    action = await unit.run('my-action')
-    assert action.results == <foo>
-    
-    # What this means depends on the workload:
-    assert charm_operates_correctly()  
-```
-
-`python-libjuju` has, of course, an API for all inverse operations: remove an app, scale it down, remove a relation...
-
-A good integration testing suite will check that the charm continues to operate as expected whenever possible, by combining these simple elements.

--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -1,15 +1,15 @@
 (write-unit-tests-for-a-charm)=
 # How to write unit tests for a charm
 
-## Setting up
+## Setting up your environment
 
-First of all, install the Ops testing framework. To do this in a virtual environment while we are developing, use `pip` or other package managers. For example:
+First of all, install the Ops testing framework. To do this in a virtual environment while we're developing, use `pip` or a different package manager. For example:
 
 ```
 pip install ops[testing]
 ```
 
-Normally, we'll include this and pin-point it to the latest minor version in the dependency group for our unit tests, for example in a `test-requirements.txt` file:
+When we want to run repeatable unit tests, we'll normally pin `ops[testing]` to the latest minor version in the dependency group for our unit tests. For example, in a `test-requirements.txt` file:
 
 ```text
 ops[testing] ~= 2.19
@@ -26,14 +26,14 @@ test = [
 
 ## Creating the charm and test files
 
-Declare our new charm type in `charm.py`:
+So that we have a charm to test, declare a placeholder charm type in `charm.py`:
 
 ```python
 class MyCharm(ops.CharmBase):
     pass        
 ```
 
-Open a new `test_foo.py` file where we will put the test code and import the [`ops.testing`](ops_testing) framework:
+Then open a new `test_foo.py` file for the test code and import the [`ops.testing`](ops_testing) framework:
 
 ```python
 import ops
@@ -46,11 +46,11 @@ To write a test function, use a `Context` object to encapsulate the charm type (
 
 This follows the typical test structure:
 
-- Arrange: arrange inputs, mock necessary functions/system calls, initialize the charm
-- Act: act by calling `Context.run`
-- Assert: assert expected outputs or function calls.
+- Arrange inputs, mock necessary functions/system calls, and initialise the charm
+- Act by calling `Context.run`
+- Assert expected outputs or function calls.
 
-For example, if `MyCharm` writes a YAML config file via `Container.Push` on the pebble-ready event:
+For example, suppose that `MyCharm` uses `Container.Push` to write a YAML config file on the pebble-ready event:
 
 ```python
 def _on_pebble_ready(self, event: ops.PebbleReadyEvent):        
@@ -59,7 +59,7 @@ def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
     # ...
 ```
 
-And we want to test this behaviour, the test might look like this:
+A test for this behaviour might look like:
 
 ```python
 import yaml
@@ -82,7 +82,7 @@ def test_pebble_ready_writes_config_file():
     ctx.run(ctx.on.pebble_ready(container=container), state_in)
 
     # Assert:
-    container_root_fs = container.get_filesystem(ctx)
+    container_root_fs = state_out.get_container("some-container").get_filesystem(ctx)
     cfg_file = container_root_fs / "etc" / "config.yaml"
     config = yaml.safe_load(cfg_file.read_text())
     assert config["message"] == "Hello, world!"
@@ -91,7 +91,7 @@ def test_pebble_ready_writes_config_file():
 
 ```{note}
 
-If you like using unittest, you should rewrite this as a method of some TestCase subclass.
+If you prefer to use unittest, you should rewrite this as a method of a `TestCase` subclass.
 
 ```
 
@@ -101,7 +101,7 @@ If you like using unittest, you should rewrite this as a method of some TestCase
 
 ## Mocking beyond the State
 
-If you wish to use the framework to test an existing charm type, you will probably need to mock out certain calls that are not covered by the `State` data structure. In that case, you will have to manually mock, patch or otherwise simulate those calls on top of what the framework does for you.
+If you wish to use the framework to test an existing charm type, you will probably need to mock out certain calls that are not covered by the `State` data structure. In that case, you will have to manually mock, patch or otherwise simulate those calls.
 
 For example, suppose that the charm we're testing uses the `KubernetesServicePatch`. To update the test above to mock that object, modify the test file to contain:
 


### PR DESCRIPTION
Changes:

How to write integration tests for a charm:

- Moved some content from the original getting started how-to here. Nothing else is changed since we will use jubilant to replace this one soon.

How to write unit tests for a charm:

- The link is changed from "write-scenario-tests-for-a-charm" to "write-unit-tests-for-a-charm".
- Moved some content from the original getting started how-to here. 
- Refactored the "Writing a test" part and fixed the example, which resolves points 1 and 2 in [this issue](https://github.com/canonical/operator/issues/1623).