### PR TITLE
chore: small typing changes related to Pebble identites

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -184,15 +184,15 @@ PlanDict = typing.TypedDict(
 
 LocalIdentityDict = typing.TypedDict('LocalIdentityDict', {'user-id': int})
 BasicIdentityDict = typing.TypedDict('BasicIdentityDict', {'password': str})
-
-
-class IdentityDict(typing.TypedDict):
-    """TypedDict for Pebble identy."""
-
-    # NOTE: ensure <IdentityAccessLiterals> are kept up to date in all locations
-    access: Literal['untrusted', 'metrics', 'read', 'admin']
-    local: NotRequired[LocalIdentityDict]
-    basic: NotRequired[BasicIdentityDict]
+IdentityDict = typing.TypedDict(
+    'IdentityDict',
+    {
+        # NOTE: ensure <IdentityAccessLiterals> are kept up to date in all locations
+        'access': Literal['untrusted', 'metrics', 'read', 'admin'],
+        'local': 'NotRequired[LocalIdentityDict]',
+        'basic': 'NotRequired[BasicIdentityDict]',
+    }
+)
 
 
 _AuthDict = TypedDict(

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2053,13 +2053,14 @@ class Identity:
     @classmethod
     def from_dict(cls, d: IdentityDict) -> Identity:
         """Create new Identity from dict parsed from JSON."""
-        d_access = d['access']
+        if 'access' not in d:
+            raise KeyError('"access" key is required in IdentityDict')
         try:
-            access = IdentityAccess(d_access)
+            access = IdentityAccess(d['access'])
         except ValueError:
             # An unknown 'access' value, perhaps from a newer Pebble version
             # We silently preserve it for roundtrip safety
-            access = typing.cast(IdentityAccess, d_access)
+            access = typing.cast(IdentityAccess, d['access'])
         local = LocalIdentity.from_dict(d['local']) if 'local' in d else None
         basic = BasicIdentity.from_dict(d['basic']) if 'basic' in d else None
         return cls(access=access, local=local, basic=basic)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1997,6 +1997,11 @@ class IdentityAccess(str, enum.Enum):
     UNTRUSTED = 'untrusted'
 
     def __str__(self) -> str:
+        """Return the string value of the enum member as if it were really just a string.
+
+        This aligns the behaviour of (str, enum.Enum) with Python 3.11's StrEnum.
+        For example: str(IdentityAccess.ADMIN) -> 'admin'
+        """
         return str.__str__(self)
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -190,7 +190,7 @@ class IdentityDict(typing.TypedDict):
     """TypedDict for Pebble identy."""
 
     # NOTE: ensure <IdentityAccessLiterals> are kept up to date in all locations
-    access: IdentityAccess | Literal['untrusted', 'metrics', 'read', 'admin']
+    access: Literal['untrusted', 'metrics', 'read', 'admin']
     local: NotRequired[LocalIdentityDict]
     basic: NotRequired[BasicIdentityDict]
 
@@ -2070,7 +2070,9 @@ class Identity:
 
     def to_dict(self) -> IdentityDict:
         """Convert this identity to its dict representation."""
-        result: IdentityDict = {'access': self.access}
+        result: IdentityDict = {
+            'access': str(self.access)  # pyright: ignore[reportAssignmentType]
+        }
         if self.local is not None:
             result['local'] = self.local.to_dict()
         if self.basic is not None:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1996,6 +1996,9 @@ class IdentityAccess(str, enum.Enum):
     METRICS = 'metrics'
     UNTRUSTED = 'untrusted'
 
+    def __str__(self) -> str:
+        return str.__str__(self)
+
 
 @dataclasses.dataclass
 class LocalIdentity:

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3983,6 +3983,14 @@ class TestIdentity:
             access=pebble.IdentityAccess.ADMIN, local=pebble.LocalIdentity(user_id=42)
         )
 
+    def test_local_identity_from_dict_with_access_enum(self):
+        identity = pebble.Identity.from_dict(
+            {'access': pebble.IdentityAccess.ADMIN, 'local': {'user-id': 42}}
+        )
+        assert identity == pebble.Identity(
+            access=pebble.IdentityAccess.ADMIN, local=pebble.LocalIdentity(user_id=42)
+        )
+
     def test_local_identity_to_dict(self):
         identity = pebble.Identity(
             access=pebble.IdentityAccess.ADMIN, local=pebble.LocalIdentity(user_id=42)
@@ -3992,6 +4000,16 @@ class TestIdentity:
     def test_basic_identity_from_dict(self):
         identity = pebble.Identity.from_dict({
             'access': 'metrics',
+            'basic': {'password': 'hashed password'},
+        })
+        assert identity == pebble.Identity(
+            access=pebble.IdentityAccess.METRICS,
+            basic=pebble.BasicIdentity(password='hashed password'),
+        )
+
+    def test_basic_identity_from_dict_with_access_enum(self):
+        identity = pebble.Identity.from_dict({
+            'access': pebble.IdentityAccess.METRICS,
             'basic': {'password': 'hashed password'},
         })
         assert identity == pebble.Identity(

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -23,7 +23,6 @@ import socket
 import tempfile
 import typing
 import unittest
-import unittest.mock
 import unittest.util
 
 import pytest
@@ -4012,11 +4011,16 @@ class TestIdentity:
 
     def test_no_access(self):
         with pytest.raises(KeyError):
-            raw: pebble.IdentityDict = {'local': {'user-id': 42}}
+            raw: pebble.IdentityDict = {  # pyright: ignore[reportAssignmentType]
+                'local': {'user-id': 42}
+            }
             pebble.Identity.from_dict(raw)
 
     def test_invalid_access(self):
-        raw: pebble.IdentityDict = {'access': 'foo', 'local': {'user-id': 42}}  # type: ignore
+        raw: pebble.IdentityDict = {
+            'access': 'foo',  # pyright: ignore[reportAssignmentType]
+            'local': {'user-id': 42},
+        }
         identity = pebble.Identity.from_dict(raw)
         assert identity.access == 'foo'
 


### PR DESCRIPTION
This PR makes a couple of small typing changes to the Pebble identities PR, and adds a couple of test cases accordingly.

Key changes:

1. Use `NotRequired` instead of `Optional` in `IdentityDict`.
2. Override `__str__` method on `IdentityAccess` to match behaviour of `StrEnum` (`str(IdentityAccess.ADMIN) == 'admin'`).
3. Change `Identity.access` type to `IdentityAccess | Literal['untrusted', ...]`.

Reasoning for `Identity.access` type:

- We want users to be able to do `identity.access = 'admin'` or `identity.access = IdentityAccess.ADMIN`.
- It's good to communicate that the value might be just a string, not a enum member (with `.value` and `.name` attributes), if we get a new/unknown access value from Pebble.
- It's good to use the `IdentityAccess | Literal` instead of `IdentityAccess | str` (despite being a white lie) so that users get warnings about typos -- if they explicitly want to use a bad value they can `type: ignore`.